### PR TITLE
Prevent registration of ubx frame objects

### DIFF
--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -55,4 +55,17 @@ class TestFactory:
     def test_construct_unkown_frame(self, frame_factory):
         with pytest.raises(KeyError):
             data = bytearray.fromhex('11 22')
-            f = frame_factory.build_with_data(UbxAckAck.CID, data)
+            frame_factory.build_with_data(UbxAckAck.CID, data)
+
+    def test_only_prototype_classes_can_be_registered(self, frame_factory):
+        ack = UbxAckAck()
+        with pytest.raises(Exception):
+            frame_factory.register(ack)
+
+    def test_throws_when_unknown_frame_shall_be_built(self, frame_factory):
+        unregistered_cid = UbxCID(0xCA, 0xFE)
+        with pytest.raises(KeyError):
+            frame_factory.build(unregistered_cid)
+
+        with pytest.raises(KeyError):
+            frame_factory.build_with_data(unregistered_cid, "12345")

--- a/ubxlib/frame_factory.py
+++ b/ubxlib/frame_factory.py
@@ -1,3 +1,6 @@
+import logging
+
+logger = logging.getLogger('gnss_tool')
 
 
 class FrameFactory(object):
@@ -26,13 +29,26 @@ class FrameFactory(object):
         self.__frames = dict()
 
     def register(self, frame_class):
-        x = frame_class()
+        """
+        Registers a UXB frame class
+
+        You have to register all frames classes that you expect to receive.
+        The ubx servers require these prototypes to build the correct ubx frames.
+
+        Notes:
+        - Register each frame class only once
+        - Register the prototype class not instances (objects)
+        """
+        # Class shall be registered not instances
+        if not isinstance(frame_class, type):
+            raise Exception("Can only register classes not instances (objects)")
 
         # Registering the same frame class multiple times is considered
         # bad style. For now we just ignore the call. Future versions
         # will assert.
         if frame_class.CID in self.__frames:
-            # assert False
+            logger.warning(f'trying to register {frame_class} multiple times')
+            logger.warning(f'future releases will throw an Exception')
             return
 
         self.__frames[frame_class.CID] = frame_class
@@ -40,15 +56,19 @@ class FrameFactory(object):
     def build(self, cid):
         """
         Constructs an empty frame of the desired type
+
+        Will throw KeyError if frame class is not known
         """
-        frame_type = self.__frames[cid]
-        frame = frame_type()
+        frame_class = self.__frames[cid]
+        frame = frame_class()
         return frame
 
     def build_with_data(self, cid, data):
         """
         Constructs the desired frame and fills it with provided data
+
+        Will throw KeyError if frame class is not known
         """
-        frame_type = self.__frames[cid]
-        frame = frame_type.construct(data)
+        frame_class = self.__frames[cid]
+        frame = frame_class.construct(data)
         return frame


### PR DESCRIPTION
Frame factory requires frame prototypes (classes) to
operate on. It is an error to register instances (objects)
of uxb frames.