### PR TITLE
server_tty: Flush data before switching baudrate

### DIFF
--- a/ubxlib/server_tty.py
+++ b/ubxlib/server_tty.py
@@ -30,6 +30,8 @@ class GnssUBlox(UbxServerBase_):
         super().cleanup()
 
     def set_baudrate(self, baud):
+        # Making sure all data are sent before switching
+        self.serial_port.flush()
         self.serial_port.baudrate = baud
 
     def scan(self, interval_in_s=1.500):


### PR DESCRIPTION
Switching the baudrate too fast can lead to loss of data if the driver
has not already sent them. That's why we need to make sure everything
has been sent before switching.